### PR TITLE
Allows "*" as a wildcard attribute

### DIFF
--- a/HTMLTags_body.php
+++ b/HTMLTags_body.php
@@ -46,7 +46,8 @@ class HTMLTags {
 		$attributes = array();
 		foreach ( $args as $key => $value ) {
 			if ( $key == 'tagname' ) { continue; }
-			if ( in_array( $key, $wgHTMLTagsAttributes[$tagName] ) ) {
+			if ( in_array( $key, $wgHTMLTagsAttributes[$tagName] )
+			  || in_array( '*', $wgHTMLTagsAttributes[$tagName] ) ) {
 				$value = $parser->replaceVariables( $value, $frame );
 				// Prevent JS injection into, for instance,
 				// the "href" attribute.


### PR DESCRIPTION
Thus a configuration line could say, for example, `$wgHTMLTagsAttributes['img'] = array( '*' );`, to allow IMG tags with any set of attributes.  The author doesn't need to come up with a comprehensive list beforehand.
